### PR TITLE
Update abstract-socket version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "xml2js": "0.1.14"
   },
   "optionalDependencies": {
-    "abstract-socket": "^0.1.0"
+    "abstract-socket": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
`abstract-socket` version `0.1.0` depended on `nan` version `~1.1.0`, which had issues with compiling for io.js / Atom.

Version `1.0.0` now depends on `nan` version `~1.7.0`. This fixes the issue and as far as I can tell, it still works perfectly fine with `dbus-native`. Since `dbus-native` depends on `abstract-socket` version `^0.1.0`, it doesn't download the new version so `dbus-native` doesn't work with io.js / Atom.