### PR TITLE
Handle Introspect method requests from D-Feet

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -118,12 +118,12 @@ module.exports = function bus(conn, opts) {
            self.signals.emit(self.mangle(msg), msg.body, msg.signature);
        } else { // methodCall
 
+           if (stdDbusIfaces(msg, self))
+               return;
+
            // exported interfaces handlers
            var obj, iface, impl;
            if (obj = self.exportedObjects[msg.path]) {
-
-               if (stdDbusIfaces(msg, self))
-                   return;
 
                if (iface = obj[msg['interface']]) {
                    // now we are ready to serve msg.member


### PR DESCRIPTION
Handle Introspect method requests for paths that are not found in the list of exported objects. Fixes exception thrown by D-Feet during introspection. Issue #76