### PR TITLE
Updates dependency abstract-socket to 1.0.1; fixes ARM compilation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "xml2js": "0.1.14"
   },
   "optionalDependencies": {
-    "abstract-socket": "^1.0.0"
+    "abstract-socket": "^1.0.1"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
Fixes: ARM fails to compile with iojs for the optional dependency `abstract-socket` at current specified version `1.0.0`.

Related: [https://github.com/saghul/node-abstractsocket/issues/5](https://github.com/saghul/node-abstractsocket/issues/5)