### PR TITLE
Do not call process.getuid() on Windows

### DIFF
--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -29,7 +29,7 @@ function getCookie(context, id, cb) {
     //if (stat.mode & 066)
     if (stat.mode & 022)
       return cb(new Error('User keyrings directory is writeable by other users. Aborting authentication'));
-    if (stat.uid != process.getuid())
+    if (process.hasOwnProperty('getuid') && stat.uid != process.getuid())
       return cb(new Error('Keyrings directory is not owned by the current user. Aborting authentication!'));
     fs.readFile(filename, 'ascii', function(err, keyrings) {
       if (err)

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -67,7 +67,11 @@ function tryAuth(stream, methods, cb) {
   }
 
   var authMethod = methods.shift();
-  var id = hexlify(process.getuid());
+  if(process.hasOwnProperty('getuid')) {
+    var id = hexlify(process.getuid());
+  } else {
+    var id = hexlify(0);
+  }
 
   function beginOrNextAuth() {
     readLine(stream, function(line) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dbus-native-windows",
   "author": "Andrey Sidorov <sidorares@yandex.com>",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "keywords": [
     "dbus",
     "dcop",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dbus-native",
+  "name": "dbus-native-windows",
   "author": "Andrey Sidorov <sidorares@yandex.com>",
   "version": "0.2.0",
   "keywords": [


### PR DESCRIPTION
Do not check if keyrings directory is not owned by the current user on systems that do not support user IDs (such as Windows)