### PR TITLE
Add subnodes to introspect result

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -261,9 +261,10 @@ module.exports = function bus(conn, opts) {
             var obj = new DBusObject(name, this);
             //console.log(obj);
             var introspect = require('./introspect.js');
-            introspect(obj, function(err, ifaces) {
+            introspect(obj, function(err, ifaces, nodes) {
                 if (err) return callback(err);
                 obj.proxy = ifaces;
+                obj.nodes = nodes;
                 callback(null, obj);
             });
         };

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -17,6 +17,7 @@ module.exports = function(obj, callback) {
           var i, m, s, ifaceName, method, property, signal, iface, a, arg, signature, currentIface;
           var ifaces = result['interface'];
           var xmlnodes = result['node'];
+          if (xmlnodes == null) xmlnodes = [];
 
           for (i = 1; i < xmlnodes.length; ++i) {       // Start at 1 because we want to skip the root node
               nodes.push(xmlnodes[i]['@']['name']);

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -13,8 +13,15 @@ module.exports = function(obj, callback) {
           if (err) return callback(err);
           if (!result.interface) return callback(new Error('No such interface found'));
           var proxy = {};
+          var nodes = [];
           var i, m, s, ifaceName, method, property, signal, iface, a, arg, signature, currentIface;
           var ifaces = result['interface'];
+          var xmlnodes = result['node'];
+
+          for (i = 1; i < xmlnodes.length; ++i) {       // Start at 1 because we want to skip the root node
+              nodes.push(xmlnodes[i]['@']['name']);
+          }
+
           for (i=0; i < ifaces.length; ++i) {
               iface = ifaces[i];
               ifaceName = iface['@'].name;
@@ -164,7 +171,7 @@ module.exports = function(obj, callback) {
                   //console.log('============    signal: ', name);
               }
           }
-          callback(null, proxy);
+          callback(null, proxy, nodes);
       });
     });
 }


### PR DESCRIPTION
Needed to access all subnodes of a certain node, and I noticed this module doesn't offer that functionality, although I may have overlooked something.

Anyhow, I decided to code it up, and it was surprisingly simple. Perhaps this would be useful upstream as well?

I tried to match the coding style as closely as possible.