### PR TITLE
FIX use variant return type for org.freedesktop.DBus.Properties.Get

### DIFF
--- a/lib/stdifaces.js
+++ b/lib/stdifaces.js
@@ -112,8 +112,8 @@ module.exports = function(msg, bus) {
             var propType = obj[interfaceName][0].properties[propertyName];
             if (msg.member === 'Get') {
                 var propValue = impl[propertyName];
-                reply.signature = propType;
-                reply.body = [propValue];
+                reply.signature = 'v';
+                reply.body = [[propType, propValue]];
             } else {
                 impl[propertyName] = 1234; // TODO: read variant and set property value
             }


### PR DESCRIPTION
I could never get any properties through the org.freedesktop.DBus.Properties.Get method, because the property needs to be wrapped in a variant according to spec. I assume this is a bug.