### PR TITLE
Fix a typo that prevented to send a reply with sendReply()

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -68,6 +68,7 @@ module.exports = function bus(conn, opts) {
         self.connection.message(signalMsg);
     }
 
+    // Warning: errorName must respect the same rules as interface names (must contain a dot)
     this.sendError = function(msg, errorName, errorText) {
         var reply = {
             type: constants.messageType.error,
@@ -90,7 +91,7 @@ module.exports = function bus(conn, opts) {
             signature: signature,
             body: body
         };
-       this.connection.message(msg);
+       this.connection.message(reply)
     }
 
     // route reply/error


### PR DESCRIPTION
- fix a type where `sendReply()` which sent `msg` instead of `reply`
- also add a small comment to remind the naming rules for `errorName` in `sendError()`, in relation #122 