### PR TITLE
Fix buffers

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -96,12 +96,9 @@ module.exports = function bus(conn, opts) {
 
     // route reply/error
     this.connection.on('message', function(msg) {
-       var msg = JSON.parse(JSON.stringify(msg));
        var handler;
        if (msg.type == constants.messageType.methodReturn || msg.type == constants.messageType.error) {
            handler = self.cookies[msg.replySerial];
-           if (msg.type == constants.messageType.methodReturn && msg.body)
-              msg.body.unshift(null); // first argument - no errors, null
            if (handler) {
               delete self.cookies[msg.replySerial];
               var props = {
@@ -110,10 +107,13 @@ module.exports = function bus(conn, opts) {
                  message: msg,
                  signature: msg.signature
               };
-              if (msg.type == constants.messageType.methodReturn)
-                 handler.apply(props, msg.body); // body as array of arguments
-              else
-                 handler.call(props, msg.body);  // body as first argument
+              var args = msg.body || [];
+              if (msg.type == constants.messageType.methodReturn) {
+                 args = [null].concat(args); // first argument - no errors, null
+                 handler.apply(props, args); // body as array of arguments
+              } else {
+                 handler.call(props, args);  // body as first argument
+              }
            }
        } else if (msg.type == constants.messageType.signal) {
            self.signals.emit(self.mangle(msg), msg.body, msg.signature);

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -166,7 +166,10 @@ describe('marshall/unmarshall', function() {
          ['aii', [[1, 2, 3, 4, 5, 6], 10]],
          ['a(ai)', [[  [[1, 2, 3, 4, 5, 6]], [[15, 4, 5, 6]] ]]],
          ['aai', [[[1, 2, 3, 4, 5, 6], [15, 4, 5, 6]]]],
-     ]
+     ],
+     'buffers': [
+         ['ayay', [Buffer([0, 1, 2, 3, 4, 5, 6, 0xff]), Buffer([])]],
+     ],
   };
 
   var testName, testData, testNum;


### PR DESCRIPTION
This removes the JSON.parse(JSON.stringify(...)) that breaks the buffers produced by unmarshalling arrays of bytes.

This also adds a simple test for the marshalling/unmarshalling of buffers, which is unrelated to the above but seemed to be missing. Adding a test for the actual fix I did is more complicated and I was too lazy.