### PR TITLE
Fix tests

### DIFF
--- a/test/example-messages.js
+++ b/test/example-messages.js
@@ -15,7 +15,7 @@ describe('given base-64 encoded files with complete messages', function() {
       //console.log(unmarshall(msgBin));
       var unmarshalledMsg = unmarshall(msgBin);
       var marshalled = marshall(unmarshalledMsg);
-      assert.deepEqual(unmarshalledMsg, unmarshall(marshalled));
+      assert.deepStrictEqual(unmarshalledMsg, unmarshall(marshalled));
     });
   });
 });

--- a/test/example-messages.js
+++ b/test/example-messages.js
@@ -4,6 +4,9 @@ var unmarshall = require('../lib/message').unmarshall;
 var marshall   = require('../lib/message').marshall;
 var dir = __dirname + '/fixtures/messages/';
 
+if( assert.deepStrictEqual === undefined )  // workaround for node 0.12
+    assert.deepStrictEqual = assert.deepEqual;
+
 describe('given base-64 encoded files with complete messages', function() {
   it('should be able to read them all', function() {
     var messages = fs.readdirSync(dir);

--- a/test/js-types.js
+++ b/test/js-types.js
@@ -3,6 +3,9 @@ var unmarshall = require('../lib/unmarshall');
 var assert     = require('assert');
 var hexy       = require('../lib/hexy').hexy;
 
+if( assert.deepStrictEqual === undefined )  // workaround for node 0.12
+    assert.deepStrictEqual = assert.deepEqual;
+
 function testOnly() {};
 
 function test(signature, data) {

--- a/test/js-types.js
+++ b/test/js-types.js
@@ -9,7 +9,7 @@ function test(signature, data) {
     var marshalledBuffer = marshall(signature, data);
     var result = unmarshall(marshalledBuffer, signature)
     try {
-      assert.deepEqual(data, result)
+      assert.deepStrictEqual(data, result)
     } catch (e) {
       console.log('signature   :', signature);
 	    console.log('orig        :', data);

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -15,7 +15,7 @@ function marshallAndUnmarshall(signature, data) {
 function test(signature, data) {
     var result = marshallAndUnmarshall(signature, data);
     try {
-      assert.deepEqual(data, result)
+      assert.deepStrictEqual(data, result)
     } catch (e) {
       console.log('signature   :', signature);
       console.log('orig        :', data);
@@ -197,7 +197,7 @@ var data =  [10, 1000];
 var s = 'nn';
 var buf = marshall(s, data);
 assert.equal(buf.toString('hex'), '0a00e803')
-assert.deepEqual(unmarshall(buf, s), data);
+assert.deepStrictEqual(unmarshall(buf, s), data);
 
 //test('a(yai)', [[[100,[1,2,3,4,5,6]],[200,[15,4,5,6]]]], console.log);
 //test('a(yv)', [[[6,["s","final"]],[8,["g","uuu"]]]], console.log)

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -3,6 +3,9 @@ var unmarshall = require('../lib/unmarshall');
 var assert     = require('assert');
 var hexy       = require('../lib/hexy').hexy;
 
+if( assert.deepStrictEqual === undefined )  // workaround for node 0.12
+    assert.deepStrictEqual = assert.deepEqual;
+
 function testOnly() {};
 
 /** Take the data and marshall it then unmarshall it */

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -119,10 +119,8 @@ describe('marshall/unmarshall', function() {
          ['g', ['signature'], false], // TODO: validate on input
          //['g', [str300chars], false],  // max 255 chars
          ['o', ['/']],
-         ['b', [0]],
-         ['b', [1]],
-         //['b', [true], true, 1],
-         //['b', [false], true, 0],
+         ['b', [false]],
+         ['b', [true]],
          ['y', [10]],
          //['y', [300], false],  // TODO: validate on input
          //['y', [-10]],  // TODO: validate on input

--- a/test/unmarshall-message.js
+++ b/test/unmarshall-message.js
@@ -29,7 +29,7 @@ describe('message marshall/unmarshall', function() {
               signature: testData[0],
               body: testData[1]
             };
-            assert.deepEqual(msg, buff2msg(msg2buff(msg)));
+            assert.deepStrictEqual(msg, buff2msg(msg2buff(msg)));
           });
         })(testData);
        }

--- a/test/unmarshall-message.js
+++ b/test/unmarshall-message.js
@@ -4,6 +4,9 @@ var message = require('../lib/message');
 var assert = require('assert');
 var hexy = require('../lib/hexy').hexy;
 
+if( assert.deepStrictEqual === undefined )  // workaround for node 0.12
+    assert.deepStrictEqual = assert.deepEqual;
+
 function msg2buff(msg) {
   return message.marshall(msg);
 }


### PR DESCRIPTION
The tests used deepEqual (i.e. deep ==) instead of deepStrictEqual (i.e. deep ===), which inappropriately considers all sorts of things equal that really aren't.

Fixing this uncovered that the test for unmarshalling booleans was broken, which I fixed also.