### PR TITLE
Update abstract-socket dependency and make it optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,12 @@
     "dbus2js": "./bin/dbus2js.js"
   },
   "dependencies": {
-    "abstract-socket": "^1.1.0",
     "event-stream": "^3.1.7",
     "put": "0.0.6",
     "xml2js": "0.1.14"
   },
   "optionalDependencies": {
-    "abstract-socket": "^1.0.1"
+    "abstract-socket": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
This PR updates `abstract-socket` to v2.0 and removes from the required dependencies allowing it to be optional. Looks #97 added it as a required dependency and did not update the optional version number. The [npm docs](https://docs.npmjs.com/files/package.json#optionaldependencies) seem to imply that `optionalDependencies` will override `dependencies` and it is not recommended to use both.