### PR TITLE
64bit cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ options:
    - port - TCP port
    - host - TCP host
    - busAddress - encoded bus address. Default is `DBUS_SESSION_BUS_ADDRESS` environment variable. See http://dbus.freedesktop.org/doc/dbus-specification.html#addresses
+   - authMethods - array of authentication methods, which are attempted in the order provided (default:['EXTERNAL', 'DBUS_COOKIE_SHA1', 'ANONYMOUS'])
    - ayBuffer - boolean (default:true): if true 'ay' dbus fields are returned as buffers
    - ReturnLongjs - boolean (default:false): if true 64 bit dbus fields (x/t) are read out as Long.js objects, otherwise they are converted to numbers (which should be good up to 53 bits)
    - ( TODO: add/document option to use adress from X11 session )
@@ -95,6 +96,14 @@ conn.message({
 conn.on('message', function(msg) { console.log(msg); });
 ```
 
+### Note on INT64 'x' and UINT64 't'
+Long.js is used for 64 Bit support. https://github.com/dcodeIO/long.js
+The following javascript types can be marshalled into 64 bit dbus fields:
+   - typeof 'number' up to 53bits
+   - typeof 'string' (consisting of decimal digits with no separators) up to full 64bit range
+   - Long.js objects (or object with compatible properties)
+
+By default 64 bit dbus fields are unmarshalled into a 'number' (with precision loss beyond 53 bits). Use {ReturnLongjs:true} option to return the actual Long.js object and preserve the entire 64 bits.
 
 ### Links
    - http://cgit.freedesktop.org/dbus - freedesktop reference C library

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ conn.on('message', function(msg) { console.log(msg); });
 Long.js is used for 64 Bit support. https://github.com/dcodeIO/long.js
 The following javascript types can be marshalled into 64 bit dbus fields:
    - typeof 'number' up to 53bits
-   - typeof 'string' (consisting of decimal digits with no separators) up to full 64bit range
+   - typeof 'string' (consisting of decimal digits with no separators or '0x' prefixed hexadecimal) up to full 64bit range
    - Long.js objects (or object with compatible properties)
 
 By default 64 bit dbus fields are unmarshalled into a 'number' (with precision loss beyond 53 bits). Use {ReturnLongjs:true} option to return the actual Long.js object and preserve the entire 64 bits.

--- a/lib/dbuffer.js
+++ b/lib/dbuffer.js
@@ -1,5 +1,4 @@
 var Long = require('long');
-var objectAssign = require('object-assign');
 
 var isSimpleType = {};
 'ybnquigsoxtd'.split(' ').forEach(function(t) {
@@ -9,9 +8,10 @@ var isSimpleType = {};
 // Buffer + position + global start position ( used in alignment )
 function DBusBuffer(buffer, startPos, options)
 {
-  //if (typeof(options) !== 'object') options = {};
-  //this.options = Object.assign({ ayBuffer: true, ReturnLongjs: false }, options);
-  this.options = objectAssign({ ayBuffer: true, ReturnLongjs: false }, options);
+  if (typeof(options) !== 'object') options = { ayBuffer: true, ReturnLongjs: false }; // default settings object
+  else if (options.ayBuffer == undefined) options.ayBuffer = true; // enforce truthy default props
+  this.options = options;
+  //this.options = Object.assign({ ayBuffer: true, ReturnLongjs: false }, options); // or use 'object-assign' polyfill
   this.buffer = buffer;
   this.startPos = startPos ? startPos : 0,
   this.pos = 0;
@@ -195,9 +195,6 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
     //  throw new Error('string is not a valid object path'));
   case 'x': //signed
     this.align(3);
-    // TODO: BE 0x100000000*this.readInt32() + this.readInt32();
-    // TODO: use bn.js
-    //return this.readInt32() + 0x100000000*this.readInt32();
     var word0 = this.readInt32();
     var word1 = this.readInt32();
     var data = Long.fromBits(word0, word1, false);
@@ -207,9 +204,6 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
     this.align(3);
     var word0 = this.readInt32();
     var word1 = this.readInt32();
-    /* if (!(word1 & 0x80000000))
-      return word0 + 0x100000000*word1;
-    return -((((~word1)>>>0) * 0x100000000) + ((~word0)>>>0) + 1); */
     var data = Long.fromBits(word0, word1, true);
     if (this.options.ReturnLongjs) return data;
     return data.toNumber(); // convert to number (good up to 53 bits)

--- a/lib/marshallers.js
+++ b/lib/marshallers.js
@@ -165,12 +165,10 @@ var MakeSimpleMarshaller = function(signature) {
         case 't':
             //UINT64
             marshaller.check = function(data) {
-                checkLong(data,false);
+                return checkLong(data,false);
             };
             marshaller.marshall = function(ps,data) {
-                this.check(data);
-                // Use Long.js to convert number/string/object to split 64 bit value
-                data = makeLong(data,false);
+                data = this.check(data);
                 align(ps, 8);
                 ps.word32le(data.low);
                 ps.word32le(data.high);
@@ -180,12 +178,10 @@ var MakeSimpleMarshaller = function(signature) {
         case 'x':
             //INT64
             marshaller.check = function(data) {
-                checkLong(data, true);
+                return checkLong(data, true);
             };
             marshaller.marshall = function(ps,data) {
-                this.check(data);
-                // Use Long.js to convert number/string/object to split 64 bit value
-                data = makeLong(data, true);
+                data = this.check(data);
                 align(ps, 8);
                 ps.word32le(data.low);
                 ps.word32le(data.high);
@@ -243,10 +239,11 @@ var checkBoolean = function(data) {
         throw new Error("Data: "+ data +" was not of type boolean");
 };
 
-// 'fromValue' from Long.js does not pass through the 'unsigned' argument currently, so we duplicate it here with some tweaks
+// This is essentially a tweaked version of 'fromValue' from Long.js with error checking.
+// This can take number or string of decimal characters or 'Long' instance (or Long-style object with props low,high,unsigned).
 var makeLong = function(val, signed) {
-    if (val instanceof Long)
-        return val;
+    if (val instanceof Long) return val;
+    if (val instanceof Number) val = val.valueOf();
     if (typeof val === 'number')
     {
         try {   // Long.js won't alert you to precision loss in passing more than 53 bit ints through a double number, so we check here
@@ -258,7 +255,7 @@ var makeLong = function(val, signed) {
         try {return Long.fromNumber(val, !signed);}
         catch (e) { e.message = "Error converting number to 64bit integer '" + e.message + "'"; throw e;}
     }
-    if (typeof val === 'string')
+    if (typeof val === 'string' || val instanceof String)
     {
         val = val.trim(); // extra whitespace can throw off the parsing
         try {var data = Long.fromString(val, !signed);}
@@ -275,7 +272,7 @@ var makeLong = function(val, signed) {
 
 var checkLong = function(data, signed) {
     if (!Long.isLong(data)) {
-        data = makeLong(data, signed); // this can take number or string of decimal characters or 'Long' instance (or Long-style object with props low,high,unsigned)
+        data = makeLong(data, signed);
     }
 
     // Do we enforce that Long.js object unsigned/signed match the field even if it is still in range?
@@ -293,4 +290,5 @@ var checkLong = function(data, signed) {
             throw new Error("Data: "+ data +" was out of range (64-bit unsigned)");
         }
     }
+    return data;
 };

--- a/lib/marshallers.js
+++ b/lib/marshallers.js
@@ -259,9 +259,13 @@ var makeLong = function(val, signed) {
     {
         var radix = 10;
         val = val.trim().toUpperCase(); // remove extra whitespace and make uppercase (for hex)
-        if (val.substring(0,2)==='0X') { // Would anyone do a negative hex like '-0xBEEF' ? Not likely?
+        if (val.substring(0,2)==='0X') {
             radix = 16;
             val = val.substring(2);
+        }
+        else if (val.substring(0,3)==='-0X') { // unusual, but just in case?
+            radix = 16;
+            val = '-' + val.substring(3);
         }
         val = val.replace(/^0+(?=\d)/, ''); // dump leading zeroes
         try {var data = Long.fromString(val, !signed, radix);}

--- a/lib/marshallers.js
+++ b/lib/marshallers.js
@@ -257,12 +257,18 @@ var makeLong = function(val, signed) {
     }
     if (typeof val === 'string' || val instanceof String)
     {
-        val = val.trim(); // extra whitespace can throw off the parsing
-        try {var data = Long.fromString(val, !signed);}
+        var radix = 10;
+        val = val.trim().toUpperCase(); // remove extra whitespace and make uppercase (for hex)
+        if (val.substring(0,2)==='0X') { // Would anyone do a negative hex like '-0xBEEF' ? Not likely?
+            radix = 16;
+            val = val.substring(2);
+        }
+        val = val.replace(/^0+(?=\d)/, ''); // dump leading zeroes
+        try {var data = Long.fromString(val, !signed, radix);}
         catch (e) { e.message = "Error converting string to 64bit integer '" + e.message + "'"; throw e;}
         // If string represents a number outside of 64 bit range, it can quietly overflow.
         // We assume if things converted correctly the string coming out of Long should match what went into it.
-        if (data.toString() !== val) throw new Error("Data: '"+ val + "' did not convert correctly to " + (signed?"signed":"unsigned") + " 64 bit");
+        if (data.toString(radix).toUpperCase() !== val) throw new Error("Data: '"+ val + "' did not convert correctly to " + (signed?"signed":"unsigned") + " 64 bit");
         return data;
     }
     // Throws for non-objects, converts non-instanceof Long:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "event-stream": "^3.1.7",
     "long": "^3.0.1",
-    "object-assign": "^4.1.1",
     "put": "0.0.6",
     "xml2js": "0.1.14"
   },

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -181,6 +181,10 @@ describe('marshall/unmarshall', function() {
         ["x", [LongMinS64], false, [LongMinS64], {ReturnLongjs:true}],
         ["t", [LongMaxU64], false, [LongMaxU64], {ReturnLongjs:true}],
         ["t", [LongMinU64], false, [LongMinU64], {ReturnLongjs:true}],
+        ["x", [{low:LongMaxS64.low,high:LongMaxS64.high,unsigned:LongMaxS64.unsigned}], false, [LongMaxS64], {ReturnLongjs:true}], // non-instance Longjs object to objects
+        ["x", [{low:LongMaxS53.low,high:LongMaxS53.high,unsigned:LongMaxS53.unsigned}], false, [9007199254740991]],
+        ["t", [{low:LongMaxU64.low,high:LongMaxU64.high,unsigned:LongMaxU64.unsigned}], false, [LongMaxU64], {ReturnLongjs:true}],
+        ["t", [{low:LongMaxU53.low,high:LongMaxU53.high,unsigned:LongMaxU53.unsigned}], false, [9007199254740991]],
         ["x", [new String(9007199254740991)], false, [9007199254740991]], // quick check String instance conversion
         ["t", [new String("9007199254740991")], false, [9007199254740991]],
         ["x", [new Number(9007199254740991)], false, [9007199254740991]], // quick check Number instance conversion

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -181,6 +181,10 @@ describe('marshall/unmarshall', function() {
         ["x", [LongMinS64], false, [LongMinS64], {ReturnLongjs:true}],
         ["t", [LongMaxU64], false, [LongMaxU64], {ReturnLongjs:true}],
         ["t", [LongMinU64], false, [LongMinU64], {ReturnLongjs:true}],
+        ["x", [new String(9007199254740991)], false, [9007199254740991]], // quick check String instance conversion
+        ["t", [new String("9007199254740991")], false, [9007199254740991]],
+        ["x", [new Number(9007199254740991)], false, [9007199254740991]], // quick check Number instance conversion
+        ["t", [new Number("9007199254740991")], false, [9007199254740991]],
      ],
      'simple structs': [
          ['(yyy)y', [[1, 2, 3], 4]],

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -11,6 +11,7 @@ var LongMinU64 = Long.fromString("0", true);
 var LongMaxS53 = Long.fromString("9007199254740991", false);
 var LongMinS53 = Long.fromString("-9007199254740991", false);
 var LongMaxU53 = Long.fromString("9007199254740991", true);
+var LongMinU53 = Long.fromString("0", true);
 
 if( assert.deepStrictEqual === undefined )  // workaround for node 0.12
     assert.deepStrictEqual = assert.deepEqual;
@@ -156,6 +157,10 @@ describe('marshall/unmarshall', function() {
          ['u', [1048576]],
          ['u', [0]],
          //['u', [-1], false]  // TODO validate input, should fail
+        ["x", [9007199254740991]], // 53bit numbers convert to 53bit numbers
+        ["x", [-9007199254740991]],
+        ["t", [9007199254740991]],
+        ["t", [0]],
         ["x", ["9007199254740991"], false, [9007199254740991]], // strings should parse and convert to 53bit numbers
         ["x", ["-9007199254740991"], false, [-9007199254740991]],
         ["t", ["9007199254740991"], false, [9007199254740991]],
@@ -163,12 +168,19 @@ describe('marshall/unmarshall', function() {
         ["x", [LongMaxS53], false, [9007199254740991]], // make sure Longjs objects convert to 53bit numbers
         ["x", [LongMinS53], false, [-9007199254740991]],
         ["t", [LongMaxU53], false, [9007199254740991]],
-        ["x", [LongMaxS64], false, [LongMaxS64], {ReturnLongjs:true}], // make sure Longjs object returns work
+        ["t", [LongMinU53], false, [0]],
+        ["x", [9007199254740991], false, [LongMaxS53], {ReturnLongjs:true}], // 53bit numbers to objects
+        ["x", [-9007199254740991], false, [LongMinS53], {ReturnLongjs:true}],
+        ["t", [9007199254740991], false, [LongMaxU53], {ReturnLongjs:true}],
+        ["t", [0], false, [LongMinU53], {ReturnLongjs:true}],
+        ["x", ["9223372036854775807"], false, [LongMaxS64], {ReturnLongjs:true}], // strings to objects
+        ["x", ["-9223372036854775808"], false, [LongMinS64], {ReturnLongjs:true}],
+        ["t", ["18446744073709551615"], false, [LongMaxU64], {ReturnLongjs:true}],
+        ["t", ["0"], false, [LongMinU64], {ReturnLongjs:true}],
+        ["x", [LongMaxS64], false, [LongMaxS64], {ReturnLongjs:true}], // Longjs object to objects
         ["x", [LongMinS64], false, [LongMinS64], {ReturnLongjs:true}],
         ["t", [LongMaxU64], false, [LongMaxU64], {ReturnLongjs:true}],
         ["t", [LongMinU64], false, [LongMinU64], {ReturnLongjs:true}],
-        ["x", [LongMaxS53], false, [LongMaxS53], {ReturnLongjs:true}],
-        ["x", [LongMinS53], false, [LongMinS53], {ReturnLongjs:true}],
      ],
      'simple structs': [
          ['(yyy)y', [[1, 2, 3], 4]],

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -165,6 +165,12 @@ describe('marshall/unmarshall', function() {
         ["x", ["-9007199254740991"], false, [-9007199254740991]],
         ["t", ["9007199254740991"], false, [9007199254740991]],
         ["t", ["0"], false, [0]],
+        ["x", ["0x1FFFFFFFFFFFFF"], false, [9007199254740991]], // hex strings
+        ["x", ["0x0000"], false, [0]],
+        ["x", ["0x7FFFFFFFFFFFFFFF"], false, [LongMaxS64], {ReturnLongjs:true}],
+        ["t", ["0x1FFFFFFFFFFFFF"], false, [9007199254740991]],
+        ["t", ["0x0000"], false, [0]],
+        ["t", ["0xFFFFFFFFFFFFFFFF"], false, [LongMaxU64], {ReturnLongjs:true}],
         ["x", [LongMaxS53], false, [9007199254740991]], // make sure Longjs objects convert to 53bit numbers
         ["x", [LongMinS53], false, [-9007199254740991]],
         ["t", [LongMaxU53], false, [9007199254740991]],

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -166,6 +166,7 @@ describe('marshall/unmarshall', function() {
         ["t", ["9007199254740991"], false, [9007199254740991]],
         ["t", ["0"], false, [0]],
         ["x", ["0x1FFFFFFFFFFFFF"], false, [9007199254740991]], // hex strings
+        ["x", ["-0x1FFFFFFFFFFFFF"], false, [-9007199254740991]],
         ["x", ["0x0000"], false, [0]],
         ["x", ["0x7FFFFFFFFFFFFFFF"], false, [LongMaxS64], {ReturnLongjs:true}],
         ["t", ["0x1FFFFFFFFFFFFF"], false, [9007199254740991]],


### PR DESCRIPTION
This is just some general cleanup for https://github.com/sidorares/node-dbus/pull/152. I filled in some test conditions and added a note to the readme. I also realized that since options only had one truthy default, it was probably not necessary to bring in object-assign to merge that one object. (I left an object assign line commented out in case object assign gets added later or nodejs 0.12 is dropped.) I also realized that the marshaller was parsing to Long objects twice (in check and then again) so I just had check return the Long to avoid the redundant conversion. Also had Long conversion handle instances of String and Number just to be thorough. Hope that has it covered for the time being.