### PR TITLE
BUGFIX: methods returning int 0 had an empty message body.

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -148,7 +148,7 @@ module.exports = function bus(conn, opts) {
                        destination: msg.sender,
                        replySerial: msg.serial
                    };
-                   if (result) {
+                   if (result != null) {
                        reply.signature = resultSignature;
                        reply.body = [result];
                    }


### PR DESCRIPTION
The issue was caused by 'result' being checked for false, but it should
be checked for null.