### PR TITLE
Update minimum Node version to 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - 0.12
   - 4.5
   - 6.6

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "prepublish": "npm prune"
   },
   "engine": {
-    "node": ">=0.10.0"
+    "node": ">=4.0"
   }
 }


### PR DESCRIPTION
`abstract-socket` requires 4.x, so it should be ok now?