### PR TITLE
Remove abstract-socket from main dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "dbus2js": "./bin/dbus2js.js"
   },
   "dependencies": {
-    "abstract-socket": "^2.0.0",
     "event-stream": "^3.1.7",
     "hexy": "^0.2.10",
     "long": "^3.0.1",


### PR DESCRIPTION
It's already in optionalDependencies, so we don't need it there.