### PR TITLE
Standardize module imports

### DIFF
--- a/bin/dbus-dissect.js
+++ b/bin/dbus-dissect.js
@@ -1,13 +1,14 @@
 // simple script to monitor incoming/outcoming dbus messages
 // needs a lot of cleanup but does the job
 
-var net = require('net');
-var abs = require('abstract-socket');
+const net = require('net');
+const abs = require('abstract-socket');
+const through2 = require('through2');
+const message = require('../lib/message');
+const readLine = require('../lib/readline');
+
 var address = process.env.DBUS_SESSION_BUS_ADDRESS;
 var m = address.match(/abstract=([^,]+)/);
-
-var readLine = require('../lib/readline.js');
-var message = require('../lib/message.js');
 
 function waitHandshake(stream, prefix, cb) {
   readLine(stream, function(line) {
@@ -46,7 +47,6 @@ net
     cli.write(buff);
     cli.pipe(s);
 
-    var through2 = require('through2');
     var cc = through2();
     var ss = through2();
 

--- a/bin/dbus2js.js
+++ b/bin/dbus2js.js
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
-var xml2js = require('xml2js');
-var dbus = require('../index.js');
-var argv = require('optimist').boolean(['server', 'dump']).argv;
+const fs = require('fs');
+const xml2js = require('xml2js');
+const dbus = require('../index');
+const optimist = require('optimist');
+
+var argv = optimist.boolean(['server', 'dump']).argv;
 
 function die(err) {
   console.log(err);
@@ -18,7 +21,6 @@ if (argv.bus == 'system') {
 
 function getXML(callback) {
   if (argv.xml) {
-    var fs = require('fs');
     fs.readFile(argv.xml, 'ascii', callback);
   } else {
     bus.invoke(

--- a/examples/active-application.js
+++ b/examples/active-application.js
@@ -1,4 +1,5 @@
-var dbus = require('../index.js');
+const dbus = require('../index');
+
 var bus = dbus.sessionBus();
 var ayatana = bus.getService('org.ayatana.bamf');
 

--- a/examples/bamf.js
+++ b/examples/bamf.js
@@ -1,4 +1,5 @@
-var dbus = require('../index.js');
+const dbus = require('../index');
+
 var bus = dbus.sessionBus();
 var ayatana = bus.getService('org.ayatana.bamf');
 

--- a/examples/basic-client.js
+++ b/examples/basic-client.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const dbus = require('../index.js');
+const dbus = require('../index');
 const EventEmitter = require('events');
 const inspect = require('util').inspect;
 

--- a/examples/basic-service.js
+++ b/examples/basic-service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const dbus = require('../index.js');
+const dbus = require('../index');
 
 /*
 	This test file's purpose is to show how to write a simple, basic DBus service with this library.

--- a/examples/client-signals.js
+++ b/examples/client-signals.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const dbus = require('../index.js');
+const dbus = require('../index');
 
 /*
 	This example shows how to query a DBus service and listen for its signals.

--- a/examples/dbusproxy/server.js
+++ b/examples/dbusproxy/server.js
@@ -1,7 +1,7 @@
-var http = require('http');
-var sockjs = require('sockjs');
-var node_static = require('node-static');
-var dbus = require('../../index.js');
+const http = require('http');
+const sockjs = require('sockjs');
+const node_static = require('node-static');
+const dbus = require('../../index');
 
 // 1. Echo sockjs server
 var sockjs_opts = {

--- a/examples/monitor.js
+++ b/examples/monitor.js
@@ -1,4 +1,5 @@
-var dbus = require('../index.js');
+const dbus = require('../index');
+
 //var conn = dbus({socket: '/var/run/dbus/system_bus_socket'});
 var conn = dbus();
 

--- a/examples/monitor1.js
+++ b/examples/monitor1.js
@@ -1,4 +1,5 @@
-var dbus = require('../index.js');
+const dbus = require('../index');
+
 var bus = dbus.systemBus();
 bus.invoke({
   member: 'AddMatch',

--- a/examples/monitor2.js
+++ b/examples/monitor2.js
@@ -1,4 +1,5 @@
-var dbus = require('../index.js');
+const dbus = require('../index');
+
 var bus = dbus.sessionBus();
 // TODO: put all matches to one string here
 bus.invoke({

--- a/examples/monitor3.js
+++ b/examples/monitor3.js
@@ -1,4 +1,5 @@
-var dbus = require('../index.js');
+const dbus = require('../index');
+
 var bus = dbus.sessionBus();
 bus.connection.on('message', console.log);
 bus.addMatch("type='signal'");

--- a/examples/notifications.js
+++ b/examples/notifications.js
@@ -1,4 +1,5 @@
-var dbus = require('../index.js');
+const dbus = require('../index');
+
 var bus = dbus.sessionBus();
 var notify = bus.getService('org.freedesktop.Notifications');
 notify.getInterface(

--- a/examples/p2p/cli.js
+++ b/examples/p2p/cli.js
@@ -1,4 +1,4 @@
-var dbus = require('../../index.js');
+const dbus = require('../../index');
 
 var count = 0;
 conn = dbus.createConnection({ port: 3333, handshake: 'none' });

--- a/examples/p2p/serv.js
+++ b/examples/p2p/serv.js
@@ -1,4 +1,4 @@
-var dbus = require('../../index.js');
+const dbus = require('../../index');
 
 dbus
   .createServer(function(conn) {

--- a/examples/return-types.js
+++ b/examples/return-types.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const dbus = require('../index.js');
+const dbus = require('../index');
 
 /*
 	This test file's purpose is to show example of possible return types for functions.

--- a/examples/service-signals.js
+++ b/examples/service-signals.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const dbus = require('../index.js');
+const dbus = require('../index');
 const inspect = require('util').inspect;
 
 /*

--- a/examples/service/client.js
+++ b/examples/service/client.js
@@ -1,4 +1,5 @@
-var dbus = require('../../index.js');
+const dbus = require('../../index');
+
 var bus = dbus.sessionBus();
 
 var destination = 'vasya.pupkin';

--- a/examples/service/client2.js
+++ b/examples/service/client2.js
@@ -1,5 +1,6 @@
-var dbus = require('../../index.js');
-var addrx11 = require('../../lib/address-x11');
+const dbus = require('../../index');
+const addrx11 = require('../../lib/address-x11');
+
 addrx11(function(err, address) {
   var bus = dbus.sessionBus({ busAddress: address });
   var name = 'some.name';

--- a/examples/service/server.js
+++ b/examples/service/server.js
@@ -1,4 +1,5 @@
-var dbus = require('../../index.js');
+const dbus = require('../../index');
+
 var bus = dbus.sessionBus();
 var name = 'vasya.pupkin';
 bus.connection.on('message', function(msg) {

--- a/examples/service/server2.js
+++ b/examples/service/server2.js
@@ -1,10 +1,10 @@
-var dbus = require('../../index.js');
+const dbus = require('../../index');
 
 // command line to test:
 // dbus-send --print-reply --type=method_call --dest='some.name' '/com/github/sidorares/1' com.example.service.respondWithDouble string:'test123'
 // dbus-send --print-reply --type=method_call --dest='some.name' '/com/github/sidorares/1' com.example.service.timesTwo double:123.4567
 
-//var addrx11 = require('../../lib/address-x11');
+//const addrx11 = require('../../lib/address-x11');
 //addrx11(function(err, address) {
 //var bus = dbus.sessionBus({busAddress: address});
 

--- a/examples/watch-unity-menu.js
+++ b/examples/watch-unity-menu.js
@@ -1,4 +1,5 @@
-var dbus = require('../index.js');
+const dbus = require('../index');
+
 var bus = dbus.sessionBus();
 var panel = bus.getService('com.canonical.Unity.Panel.Service');
 panel.getInterface(

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 // dbus.freedesktop.org/doc/dbus-specification.html
 
-var EventEmitter = require('events').EventEmitter;
-var net = require('net');
+const EventEmitter = require('events').EventEmitter;
+const net = require('net');
 
-var constants = require('./lib/constants');
-var message = require('./lib/message');
-var clientHandshake = require('./lib/handshake.js');
-var serverHandshake = require('./lib/server-handshake.js');
-var helloMessage = require('./lib/hello-message.js');
+const constants = require('./lib/constants');
+const message = require('./lib/message');
+const clientHandshake = require('./lib/handshake');
+const serverHandshake = require('./lib/server-handshake');
+const MessageBus = require('./lib/bus');
+const server = require('./lib/server');
+const helloMessage = require('./lib/hello-message');
 
 function createStream(opts) {
   if (opts.stream) return opts.stream;
@@ -132,8 +134,6 @@ function createConnection(opts) {
   return self;
 }
 
-var MessageBus = require('./lib/bus.js');
-
 module.exports = createConnection;
 
 module.exports.createClient = function(params) {
@@ -156,5 +156,4 @@ module.exports.sessionBus = function(opts) {
 module.exports.messageType = constants.messageType;
 module.exports.createConnection = module.exports;
 
-var server = require('./lib/server.js');
 module.exports.createServer = server.createServer;

--- a/lib/address-x11.js
+++ b/lib/address-x11.js
@@ -1,8 +1,8 @@
 // read dbus adress from window selection
 
-var x11 = require('x11');
-var fs = require('fs');
-var os = require('os');
+const x11 = require('x11');
+const fs = require('fs');
+const os = require('os');
 
 function getDbusAddress(callback) {
   // read machine uuid

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -1,6 +1,7 @@
-var EventEmitter = require('events').EventEmitter;
-var constants = require('./constants');
-var stdDbusIfaces = require('./stdifaces');
+const EventEmitter = require('events').EventEmitter;
+const constants = require('./constants');
+const stdDbusIfaces = require('./stdifaces');
+const introspect = require('./introspect');
 
 module.exports = function bus(conn, opts) {
   if (!(this instanceof bus)) {
@@ -259,7 +260,6 @@ module.exports = function bus(conn, opts) {
     this.bus = bus;
     this.getObject = function(name, callback) {
       var obj = new DBusObject(name, this);
-      var introspect = require('./introspect.js');
       introspect(obj, function(err, ifaces, nodes) {
         if (err) return callback(err);
         obj.proxy = ifaces;

--- a/lib/dbuffer.js
+++ b/lib/dbuffer.js
@@ -1,4 +1,5 @@
-var Long = require('long');
+const Long = require('long');
+const parseSignature = require('./signature');
 
 var isSimpleType = {};
 'ybnquigsoxtd'.split(' ').forEach(function(t) {
@@ -73,8 +74,6 @@ DBusBuffer.prototype.readString = function(len) {
   this.pos += len + 1; // dbus strings are always zero-terminated ('s' and 'g' types)
   return res;
 };
-
-var parseSignature = require('./signature.js');
 
 DBusBuffer.prototype.readTree = function readTree(tree) {
   switch (tree.type) {

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -1,9 +1,9 @@
-var crypto = require('crypto');
-var fs = require('fs');
-var path = require('path');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 
-var constants = require('./constants.js');
-var readLine = require('./readline.js');
+const constants = require('./constants');
+const readLine = require('./readline');
 
 function sha1(input) {
   var shasum = crypto.createHash('sha1');

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -1,4 +1,5 @@
-var xml2js = require('xml2js');
+const xml2js = require('xml2js');
+
 module.exports = function(obj, callback) {
   var bus = obj.service.bus;
   bus.invoke(

--- a/lib/marshall.js
+++ b/lib/marshall.js
@@ -1,9 +1,9 @@
-var assert = require('assert');
+const assert = require('assert');
 
-var parseSignature = require('./signature');
-var put = require('put');
-var Marshallers = require('./marshallers');
-var align = require('./align').align;
+const parseSignature = require('./signature');
+const put = require('put');
+const Marshallers = require('./marshallers');
+const align = require('./align').align;
 
 var marshall = (module.exports = function(signature, data, offset) {
   if (typeof offset == 'undefined') offset = 0;

--- a/lib/marshallers.js
+++ b/lib/marshallers.js
@@ -1,6 +1,6 @@
-var align = require('./align').align;
-var parseSignature = require('../lib/signature');
-var Long = require('long');
+const align = require('./align').align;
+const parseSignature = require('../lib/signature');
+const Long = require('long');
 /**
  * MakeSimpleMarshaller
  * @param signature - the signature of the data you want to check

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,8 +1,9 @@
-const marshall = require('./marshall.js');
-const constants = require('./constants.js');
-const signature = require('./signature.js');
-const DBusBuffer = require('./dbuffer.js');
-const unmarshall = require('./unmarshall.js');
+const marshall = require('./marshall');
+const constants = require('./constants');
+const signature = require('./signature');
+const DBusBuffer = require('./dbuffer');
+const unmarshall = require('./unmarshall');
+
 const headerSignature = require('./header-signature.json');
 
 module.exports.unmarshalMessages = function messageParser(

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,6 @@
-var binary = require('binary');
-var handshake = require('./handshake');
-var message = require('./message');
+const binary = require('binary');
+const handshake = require('./handshake');
+const message = require('./message');
 
 module.exports = function(dbus, opts) {
   var bs = binary(dbus.stream);

--- a/lib/portforward.js
+++ b/lib/portforward.js
@@ -1,6 +1,7 @@
-var net = require('net');
+const net = require('net');
+const hexy = require('hexy').hexy;
+
 require('abstractsocket')(net);
-var hexy = require('./lib/hexy').hexy;
 
 var address = process.env.DBUS_SESSION_BUS_ADDRESS;
 var m = address.match(/abstract=([^,]+)/);

--- a/lib/server-handshake.js
+++ b/lib/server-handshake.js
@@ -1,7 +1,7 @@
-var put = require('put');
-var crypto = require('crypto');
-var fs = require('fs');
-var readLine = require('./readline.js');
+const put = require('put');
+const crypto = require('crypto');
+const fs = require('fs');
+const readLine = require('./readline');
 
 var exports = (module.exports = function serverHandshake(stream, opts, cb) {
   stream.name = 'SERVER SERVER';

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,6 @@
-var dbus = require('../index.js');
-var EventEmitter = require('events').EventEmitter;
-var net = require('net');
+const dbus = require('../index');
+const EventEmitter = require('events').EventEmitter;
+const net = require('net');
 
 module.exports.createServer = function(handler) {
   function Server() {

--- a/lib/stdifaces.js
+++ b/lib/stdifaces.js
@@ -1,5 +1,5 @@
-var constants = require('./constants');
-var parseSignature = require('./signature');
+const constants = require('./constants');
+const parseSignature = require('./signature');
 
 // TODO: use xmlbuilder
 

--- a/lib/unmarshall.js
+++ b/lib/unmarshall.js
@@ -1,3 +1,5 @@
+const DBusBuffer = require('./dbuffer');
+
 function isValidBoolean(val) {
   return val === 1 || val === 0;
 }
@@ -19,8 +21,6 @@ function isValidBoolean(val) {
 function isValidObjectPath(path) {
   return path.match(/^(\/$)|(\/[A-Za-z0-9_]+)+$/);
 }
-
-var DBusBuffer = require('./dbuffer.js');
 
 module.exports = function unmarshall(buffer, signature, startPos, options) {
   if (!startPos) startPos = 0;

--- a/test/example-messages.js
+++ b/test/example-messages.js
@@ -1,8 +1,9 @@
-var fs = require('fs');
-var assert = require('assert');
-var unmarshall = require('../lib/message').unmarshall;
-var marshall = require('../lib/message').marshall;
-var dir = __dirname + '/fixtures/messages/';
+const fs = require('fs');
+const assert = require('assert');
+const unmarshall = require('../lib/message').unmarshall;
+const marshall = require('../lib/message').marshall;
+
+const dir = __dirname + '/fixtures/messages/';
 
 describe('given base-64 encoded files with complete messages', function() {
   it('should be able to read them all', function() {

--- a/test/js-types.js
+++ b/test/js-types.js
@@ -1,7 +1,7 @@
-var marshall = require('../lib/marshall');
-var unmarshall = require('../lib/unmarshall');
-var assert = require('assert');
-var hexy = require('hexy').hexy;
+const marshall = require('../lib/marshall');
+const unmarshall = require('../lib/unmarshall');
+const assert = require('assert');
+const hexy = require('hexy').hexy;
 
 function testOnly() {}
 

--- a/test/signature.js
+++ b/test/signature.js
@@ -1,5 +1,5 @@
-var assert = require('assert');
-var parse = require('../lib/signature');
+const assert = require('assert');
+const parse = require('../lib/signature');
 
 describe('Signature parser', function() {
   //beforeEach(function(done) {

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -1,9 +1,9 @@
-var marshall = require('../lib/marshall');
-var unmarshall = require('../lib/unmarshall');
-var assert = require('assert');
-var hexy = require('hexy').hexy;
+const marshall = require('../lib/marshall');
+const unmarshall = require('../lib/unmarshall');
+const assert = require('assert');
+const hexy = require('hexy').hexy;
+const Long = require('long');
 
-var Long = require('long');
 var LongMaxS64 = Long.fromString('9223372036854775807', false);
 var LongMinS64 = Long.fromString('-9223372036854775808', false);
 var LongMaxU64 = Long.fromString('18446744073709551615', true);

--- a/test/unmarshall-message.js
+++ b/test/unmarshall-message.js
@@ -1,8 +1,8 @@
-var marshall = require('../lib/marshall');
-var unmarshall = require('../lib/unmarshall');
-var message = require('../lib/message');
-var assert = require('assert');
-var hexy = require('hexy').hexy;
+const marshall = require('../lib/marshall');
+const unmarshall = require('../lib/unmarshall');
+const message = require('../lib/message');
+const assert = require('assert');
+const hexy = require('hexy').hexy;
 
 function msg2buff(msg) {
   return message.marshall(msg);

--- a/test/utils/address.js
+++ b/test/utils/address.js
@@ -1,4 +1,5 @@
-var addrx11 = require('../../lib/address-x11');
+const addrx11 = require('../../lib/address-x11');
+
 process.env.DISPLAY = ':0';
 addrx11(function(err, address) {
   console.log(address);

--- a/test/utils/packetcapture.js
+++ b/test/utils/packetcapture.js
@@ -1,9 +1,9 @@
-var net = require('net');
-var hexy = require('hexy').hexy;
-require('abstractsocket')(net);
-var buffs = require('buffers');
+const net = require('net');
+const hexy = require('hexy').hexy;
+const buffs = require('buffers');
+const fs = require('fs');
 
-var fs = require('fs');
+require('abstractsocket')(net);
 
 function nextPacketPos(b) {
   if (b.length < 10) return -1;

--- a/test/utils/portforv.js
+++ b/test/utils/portforv.js
@@ -1,5 +1,6 @@
-var net = require('net');
-var hexy = require('hexy').hexy;
+const net = require('net');
+const hexy = require('hexy').hexy;
+
 require('abstractsocket')(net);
 
 net

--- a/test/utils/tester.js
+++ b/test/utils/tester.js
@@ -1,9 +1,10 @@
-var fs = require('fs');
-var binarystream = require('binary');
-var packets = fs.readFileSync('./packets.bin');
-var EventEmitter = require('events').EventEmitter;
-var message = require('./lib/message');
-var hexy = require('hexy').hexy;
+const fs = require('fs');
+const binarystream = require('binary');
+const EventEmitter = require('events').EventEmitter;
+const message = require('./lib/message');
+const hexy = require('hexy').hexy;
+
+const packets = fs.readFileSync('./packets.bin');
 
 function nextPacketPos(b) {
   console.log(hexy(b, { prefix: 'SEARCHING : ' }));


### PR DESCRIPTION
Changed:

  * move all top level imports to the beginning of the file
  * use const for imports
  * add a newline between module imports and code
  * remove `.js` extension from module imports
  * move function calls (like readFileSync) out of module import section
  * move *some* module imports out of functions
  * move `require('abstract-socket')(net)` to after the import section

Not Changed:
  * "factory" imports in index.js as that would force a requirement on optional dependencies